### PR TITLE
[Fix] 예약 세부 조회 UI 당일 예약 구분

### DIFF
--- a/MEME/MEME.xcodeproj/project.pbxproj
+++ b/MEME/MEME.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		09275E822B518D150033EF34 /* ArtistHomeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09275E812B518D150033EF34 /* ArtistHomeViewController.xib */; };
 		09275E892B528A610033EF34 /* ArtistReservationStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09275E872B528A610033EF34 /* ArtistReservationStatusTableViewCell.swift */; };
 		09275E8A2B528A610033EF34 /* ArtistReservationStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09275E882B528A610033EF34 /* ArtistReservationStatusTableViewCell.xib */; };
+		0936EDDD2C5D11D300212AF0 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0936EDDB2C5D11D300212AF0 /* GoogleService-Info.plist */; };
+		0936EDDE2C5D11D300212AF0 /* memeSecret.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0936EDDC2C5D11D300212AF0 /* memeSecret.plist */; };
 		094884C72B584B7000C233E0 /* ArtistMakeupTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094884C52B584B7000C233E0 /* ArtistMakeupTagCollectionViewCell.swift */; };
 		094884C82B584B7000C233E0 /* ArtistMakeupTagCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 094884C62B584B7000C233E0 /* ArtistMakeupTagCollectionViewCell.xib */; };
 		094884CB2B584B8F00C233E0 /* ArtistPortfolioCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094884C92B584B8F00C233E0 /* ArtistPortfolioCollectionViewCell.swift */; };
@@ -349,6 +351,8 @@
 		09275E812B518D150033EF34 /* ArtistHomeViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArtistHomeViewController.xib; sourceTree = "<group>"; };
 		09275E872B528A610033EF34 /* ArtistReservationStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistReservationStatusTableViewCell.swift; sourceTree = "<group>"; };
 		09275E882B528A610033EF34 /* ArtistReservationStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArtistReservationStatusTableViewCell.xib; sourceTree = "<group>"; };
+		0936EDDB2C5D11D300212AF0 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		0936EDDC2C5D11D300212AF0 /* memeSecret.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = memeSecret.plist; sourceTree = "<group>"; };
 		094884C52B584B7000C233E0 /* ArtistMakeupTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistMakeupTagCollectionViewCell.swift; sourceTree = "<group>"; };
 		094884C62B584B7000C233E0 /* ArtistMakeupTagCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ArtistMakeupTagCollectionViewCell.xib; sourceTree = "<group>"; };
 		094884C92B584B8F00C233E0 /* ArtistPortfolioCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistPortfolioCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1129,6 +1133,8 @@
 				3142B9662B4CFFED0066CD5A /* Info.plist */,
 				09919FBA2C2AB7F900894119 /* GoogleService-Info.plist */,
 				09919FBB2C2AB7F900894119 /* memeSecret.plist */,
+				0936EDDB2C5D11D300212AF0 /* GoogleService-Info.plist */,
+				0936EDDC2C5D11D300212AF0 /* memeSecret.plist */,
 				3142B9632B4CFFED0066CD5A /* LaunchScreen.storyboard */,
 				3156D1FD2B69438800559820 /* Network */,
 				3142B9992B4D01FB0066CD5A /* extenstions */,
@@ -2160,6 +2166,8 @@
 				312B30512B550FF9008D17FC /* Pretendard-SemiBold.otf in Resources */,
 				09919FBD2C2AB7F900894119 /* memeSecret.plist in Resources */,
 				09919FBC2C2AB7F900894119 /* GoogleService-Info.plist in Resources */,
+				0936EDDE2C5D11D300212AF0 /* memeSecret.plist in Resources */,
+				0936EDDD2C5D11D300212AF0 /* GoogleService-Info.plist in Resources */,
 				31B263442B57EDE300304FBE /* TermDetailViewController.xib in Resources */,
 				315EE2D62B6658B50042A082 /* SetBusinessInfoViewController.xib in Resources */,
 			);

--- a/MEME/MEME/Artist/ArtistHome/ArtistHomeView/ArtistHomeViewController.swift
+++ b/MEME/MEME/Artist/ArtistHome/ArtistHomeView/ArtistHomeViewController.swift
@@ -30,7 +30,7 @@ class ArtistHomeViewController: UIViewController {
         artistID = getArtistID()
         profileUISet()
         reservationUISet()
-        filterReservations(reservationData: dummyReservations)
+//        filterReservations(reservationData: dummyReservations)
     }
     override func viewWillAppear(_ animated: Bool) {
         getArtistProfile(artistID)
@@ -66,11 +66,19 @@ class ArtistHomeViewController: UIViewController {
         reservationCollectionView.collectionViewLayout = self.createReservationLayout()
     }
     
-    // 프로필 완성하러 가기 버튼
+    // 전체 예약 보기 버튼
     @IBAction func showAllReservationButtonTapped(_ sender: UIButton) {
+        let nextVC = ManagementReservationsViewController()
+        navigationController?.pushViewController(nextVC, animated: true)
+    }
+    
+    // 프로필 완성하러 가기 버튼
+    @IBAction func profileSettingButtonTapped(_ sender: UIButton) {
         let nextVC = SetBusinessInfoViewController()
         navigationController?.pushViewController(nextVC, animated: true)
     }
+    
+    // 프로필 완성하러 가기 버튼
     @IBAction func notificationButtonTapped(_ sender: UIButton) {
         //        let nextVC = NotificationViewController()
         //        navigationController?.pushViewController(nextVC, animated: true)

--- a/MEME/MEME/Artist/ArtistHome/ArtistHomeView/ArtistHomeViewController.xib
+++ b/MEME/MEME/Artist/ArtistHome/ArtistHomeView/ArtistHomeViewController.xib
@@ -102,7 +102,6 @@
                                 <color key="baseForegroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </buttonConfiguration>
                             <connections>
-                                <action selector="entireReservationBtnTapped:" destination="-1" eventType="touchUpInside" id="JER-BC-U0c"/>
                                 <action selector="showAllReservationButtonTapped:" destination="-1" eventType="touchUpInside" id="0Wm-7d-PCT"/>
                             </connections>
                         </button>
@@ -182,6 +181,9 @@
                                 <fontDescription key="titleFontDescription" name="Pretendard-Medium" family="Pretendard" pointSize="14"/>
                                 <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </buttonConfiguration>
+                            <connections>
+                                <action selector="profileSettingButtonTapped:" destination="-1" eventType="touchUpInside" id="rSt-jn-haH"/>
+                            </connections>
                         </button>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -214,7 +216,7 @@
         </view>
     </objects>
     <resources>
-        <image name="chevron.right" catalog="system" width="32" height="32"/>
+        <image name="chevron.right" catalog="system" width="97" height="128"/>
         <image name="icon _bell" width="18" height="21.666666030883789"/>
         <image name="logo" width="161.66667175292969" height="100.66666412353516"/>
         <systemColor name="systemBackgroundColor">

--- a/MEME/MEME/Artist/SingleReservationManageView/SingleReservationManageViewController.swift
+++ b/MEME/MEME/Artist/SingleReservationManageView/SingleReservationManageViewController.swift
@@ -14,6 +14,7 @@ class SingleReservationManageViewController: UIViewController {
     @IBOutlet weak var cancelBarButton: UIButton!
     @IBOutlet weak var confirmReservationBarView: UIView!
     @IBOutlet weak var confirmReservationBarButton: UIButton!
+    @IBOutlet weak var confirmReservationBarLabel: UILabel!
     @IBOutlet weak var modelInfoFrameView: UIView!
     @IBOutlet weak var modelInfoView: UIView!
     @IBOutlet weak var makeupCategoryLabel: UILabel!
@@ -70,6 +71,10 @@ class SingleReservationManageViewController: UIViewController {
     
     func configure(){
         //TODO: API Response DTO 수정 후 재작성
+        if isToday(Date()){
+            cancelBarView.isHidden = true
+            confirmReservationBarLabel.text = "당일 예약은 취소 불가합니다"
+        }
     }
     
     @IBAction private func reservationCancelBtnDidTap(_ sender: UIButton) {
@@ -111,6 +116,10 @@ extension SingleReservationManageViewController{
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter.date(from: dateString)
+    }
+    private func isToday(_ date: Date?) -> Bool {
+        guard let date = date else { return false }
+        return Calendar.current.isDateInToday(date)
     }
 }
 

--- a/MEME/MEME/Artist/SingleReservationManageView/SingleReservationManageViewController.xib
+++ b/MEME/MEME/Artist/SingleReservationManageView/SingleReservationManageViewController.xib
@@ -26,6 +26,7 @@
                 <outlet property="cancelBarLabel" destination="2Om-41-ScY" id="3AG-ZJ-5GI"/>
                 <outlet property="cancelBarView" destination="Gyk-ma-98k" id="sIn-G6-Xfl"/>
                 <outlet property="confirmReservationBarButton" destination="jRZ-hu-H9D" id="Amf-5n-hxp"/>
+                <outlet property="confirmReservationBarLabel" destination="13l-e8-kJZ" id="Omx-01-ncw"/>
                 <outlet property="confirmReservationBarView" destination="MW6-ag-qcv" id="2Hz-hb-kUO"/>
                 <outlet property="makeupCategoryLabel" destination="9ut-d9-pXx" id="p9M-fp-mTf"/>
                 <outlet property="makeupNameLabel" destination="VX9-mn-11l" id="59p-zR-G1s"/>


### PR DESCRIPTION
## 🌁 Description
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
예약 세부 조회 UI 당일 예약 구분 처리 + 아티스트 뷰 연결 수정하였습니다

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

| iPhone SE3 | iPhone 13 mini | iPhone 15 Pro |
|----|----|----|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-08-03 at 00 42 24](https://github.com/user-attachments/assets/3373ece4-588b-4789-93e5-52eea8035d1c) | ![Simulator Screenshot - iPhone 13 mini - 2024-08-03 at 00 41 47](https://github.com/user-attachments/assets/52d96785-1f94-4ce3-ae8e-729cc0c7de3b) | ![Simulator Screenshot - iPhone 15 Pro - 2024-08-03 at 00 41 18](https://github.com/user-attachments/assets/b9e9d2d6-999d-4948-81bc-97f3a82d34c3) |

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->


## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->
- API v2 명세서 나온 후에 예약 상세보기 DTO랑 API 새로 작성해야합니다!
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #118 


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->

